### PR TITLE
preload🚀

### DIFF
--- a/src/actions/EntryActions.js
+++ b/src/actions/EntryActions.js
@@ -4,13 +4,23 @@ import config from "../config";
 export const GET_ENTRY_REQUEST = "GET_ENTRY_REQUEST";
 export const GET_ENTRY_SUCCESS = "GET_ENTRY_SUCCESS";
 export const GET_ENTRY_FAILURE = "GET_ENTRY_FAILURE";
+export const PRELOAD_ENTRIES = "PRELOAD_ENTRIES";
+
+export const preloadRanking = () => dispatch => {
+  const page = 1
+  return axios
+    .get(`${config.backend_api_url}/ranking/${String(page)}/preload`)
+    .then(res => {
+      dispatch({ type: PRELOAD_ENTRIES, entries: res.data });
+    })
+};
 
 export const getEntry = id => dispatch => {
-  dispatch({ type: GET_ENTRY_REQUEST });
+  dispatch({ type: GET_ENTRY_REQUEST, id });
   return axios
     .get(config.backend_api_url + "/entries/" + String(id))
     .then(res => {
-      dispatch({ type: GET_ENTRY_SUCCESS, entry: res.data });
+      dispatch({ type: GET_ENTRY_SUCCESS, entry: res.data, id });
     })
     .catch(_ => {
       dispatch({ type: GET_ENTRY_FAILURE, error: "" });

--- a/src/components/organisms/Ranking.js
+++ b/src/components/organisms/Ranking.js
@@ -6,19 +6,17 @@ import styled from "styled-components";
 import Wrapper from "../atoms/Wrapper";
 import RankingItem from "../molecules/RankingItem";
 import { getRanking } from "../../actions/RankingActions";
+import { preloadRanking } from "../../actions/EntryActions";
 
 const StyledRanking = styled.div`
   padding: 0 0 20px 0;
 `;
 
 class Ranking extends Component {
-  static fetchData({ dispatch }) {
-    return dispatch(getRanking());
-  }
-
   componentWillMount() {
     if (!this.props.hasLoaded) {
-      Ranking.fetchData({ dispatch: this.props.dispatch });
+      this.props.getRanking();
+      this.props.preloadRanking();
     }
   }
 
@@ -49,4 +47,6 @@ export default connect(store => ({
   hasLoaded: store.ranking.hasLoaded,
   ranking: store.ranking.ranking,
   error: store.ranking.error
-}))(Ranking);
+}),
+  { getRanking, preloadRanking }
+)(Ranking);

--- a/src/reducers/entries.js
+++ b/src/reducers/entries.js
@@ -1,29 +1,46 @@
 import {
   GET_ENTRY_REQUEST,
   GET_ENTRY_SUCCESS,
-  GET_ENTRY_FAILURE
+  GET_ENTRY_FAILURE,
+  PRELOAD_ENTRIES
 } from "../actions/EntryActions";
 
 const initialState = {
   hasLoaded: false,
-  url: ""
+  entries: {},
+  entry: null,
 };
 
 export default (state = initialState, action) => {
   switch (action.type) {
     case GET_ENTRY_REQUEST:
+      const entryPreloaded = state.entries && (action.id in state.entries) ? true : false
       return {
         ...state,
-        hasLoaded: false
+        hasLoaded: entryPreloaded,
+        entry: entryPreloaded ? state.entries[action.id] : null
       };
     case GET_ENTRY_SUCCESS:
       return {
         ...state,
         hasLoaded: true,
+        entries: Object.assign(state.entries, {[action.id]: action.entry}),
         entry: action.entry
       };
     case GET_ENTRY_FAILURE:
       return state;
+    case PRELOAD_ENTRIES:
+      const ObjectToDictById = array => {
+        let x = {};
+        array.forEach( val => {
+          x[val.id] = val;
+        });
+        return x;
+      }
+      return {
+        ...state,
+        entries: Object.assign(state.entries, ObjectToDictById(action.entries))
+      }
     default:
       return state;
   }


### PR DESCRIPTION
**概要**
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
https://github.com/enpitut2018/VideoSocialBookmark/issues/44

**変更内容**
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
```
state: {
  hasLoaded: boolean,
  entry: Entry,
}
```
↓
```
state: {
  hasLoaded: boolean,
  entry: Entry,
  entries: [Entry]
};
```
- ランキング取得時に`preloadRanking `も呼んで`entries`を先読みする
- `/entry/:id`アクセス時の`GET_ENTRY_REQUEST`で`entries[id]`があればそれを使う。`GET_ENTRY_SUCCESS`も呼ばれるので`entries`が古くても更新される

**補足**
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

